### PR TITLE
Fix #73 and config/connection refactoring

### DIFF
--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -722,7 +722,6 @@ function help_message() {
     echo "   -h, --help                          Show this help message."
     echo
 
-    echo $(get_fastest_vpn_connection_id)
     exit 0
 }
 

--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -591,12 +591,7 @@ function connection_to_vpn_via_dialog_menu() {
   for i in $c2; do
     server_tier=$(echo "$i" | cut -d "@" -f8)
     if [[ $server_tier -le $user_tier ]]; then
-      ID=$(echo "$i" | cut -d "@" -f1)
-      tier=$(echo "$server_tier" | tr '0' 'F' | tr '1' 'B' | tr '2' 'P')
-      score=$(echo "$i" | cut -d "@" -f9)
-      fields1=$(echo "$i" | cut -d "@" -f1-7)
-      fields2="${fields1}@${tier}@${score}"
-      data=$(echo "$fields2" | tr '@' ' ' | awk '{$1=""; print $0}' | tr ' ' '@')
+      data=$(echo "$i" | cut -d"@" -f1-7 | tr '@' ' ' | awk '{$1=""; print $0}' | tr ' ' '@')
       ARRAY+=($counter)
       ARRAY+=($data)
     fi
@@ -604,7 +599,7 @@ function connection_to_vpn_via_dialog_menu() {
   done
 
   config_id=$(dialog --clear  --ascii-lines --output-fd 1 --title "ProtonVPN-CLI" --column-separator "@" \
-    --menu "ID - Name - Country - Load - EntryIP - ExitIP - Features - Tier - Score" 35 300 "$((${#ARRAY[@]}))" "${ARRAY[@]}" )
+    --menu "ID - Name - Country - Load - EntryIP - ExitIP - Features" 35 300 "$((${#ARRAY[@]}))" "${ARRAY[@]}" )
   clear
   if [[ $config_id == "" ]]; then
     exit 2

--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -585,18 +585,22 @@ function connection_to_vpn_via_dialog_menu() {
 
   echo "Fetching ProtonVPN Servers..."
 
+  user_tier=$(cat "$(get_protonvpn_cli_home)/protonvpn_tier")
   c2=$(get_vpn_config_details)
-  counter=0
+  counter=1
   for i in $c2; do
-    ID=$(echo "$i" | cut -d "@" -f1)
-    tier=$(echo "$i" | cut -d "@" -f8 | tr '0' 'F' | tr '1' 'B' | tr '2' 'P')
-    score=$(echo "$i" | cut -d "@" -f9)
-    fields1=$(echo "$i" | cut -d "@" -f1-7)
-    fields2="${fields1}@${tier}@${score}"
-    data=$(echo "$fields2" | tr '@' ' ' | awk '{$1=""; print $0}' | tr ' ' '@')
+    server_tier=$(echo "$i" | cut -d "@" -f8)
+    if [[ $server_tier -le $user_tier ]]; then
+      ID=$(echo "$i" | cut -d "@" -f1)
+      tier=$(echo "$server_tier" | tr '0' 'F' | tr '1' 'B' | tr '2' 'P')
+      score=$(echo "$i" | cut -d "@" -f9)
+      fields1=$(echo "$i" | cut -d "@" -f1-7)
+      fields2="${fields1}@${tier}@${score}"
+      data=$(echo "$fields2" | tr '@' ' ' | awk '{$1=""; print $0}' | tr ' ' '@')
+      ARRAY+=($counter)
+      ARRAY+=($data)
+    fi
     counter=$((counter+1))
-    ARRAY+=($counter)
-    ARRAY+=($data)
   done
 
   config_id=$(dialog --clear  --ascii-lines --output-fd 1 --title "ProtonVPN-CLI" --column-separator "@" \

--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -353,6 +353,7 @@ function openvpn_connect() {
 
   config_id=$(echo "$1" | cut -d"@" -f1)
   tier=$(echo "$1" | cut -d"@" -f8)
+  name=$(echo "$1" | cut -d"@" -f2)
   selected_protocol=$2
   
   if [[ $selected_protocol == "" ]]; then
@@ -587,15 +588,19 @@ function connection_to_vpn_via_dialog_menu() {
   c2=$(get_vpn_config_details)
   counter=0
   for i in $c2; do
-    ID=$(echo "$i" | cut -d " " -f1)
-    data=$(echo "$i" | tr '@' ' ' | awk '{$1=""; print $0}' | tr ' ' '@')
+    ID=$(echo "$i" | cut -d "@" -f1)
+    tier=$(echo "$i" | cut -d "@" -f8 | tr '0' 'F' | tr '1' 'B' | tr '2' 'P')
+    score=$(echo "$i" | cut -d "@" -f9)
+    fields1=$(echo "$i" | cut -d "@" -f1-7)
+    fields2="${fields1}@${tier}@${score}"
+    data=$(echo "$fields2" | tr '@' ' ' | awk '{$1=""; print $0}' | tr ' ' '@')
     counter=$((counter+1))
     ARRAY+=($counter)
     ARRAY+=($data)
   done
 
   config_id=$(dialog --clear  --ascii-lines --output-fd 1 --title "ProtonVPN-CLI" --column-separator "@" \
-    --menu "ID - Name - Country - Load - EntryIP - ExitIP - Features" 35 300 "$((${#ARRAY[@]}))" "${ARRAY[@]}" )
+    --menu "ID - Name - Country - Load - EntryIP - ExitIP - Features - Tier - Score" 35 300 "$((${#ARRAY[@]}))" "${ARRAY[@]}" )
   clear
   if [[ $config_id == "" ]]; then
     exit 2
@@ -603,10 +608,9 @@ function connection_to_vpn_via_dialog_menu() {
 
   c=1
   for i in $c2; do
-    ID=$(echo "$i" | cut -d " " -f1)
+    ID=$(echo "$i" | cut -d "@" -f1)
     if [[ $c -eq $config_id ]]; then
-      ID=$(echo "$i" | cut -d " " -f1)
-      config_id=$ID
+      config_id=$i
       break
     fi
     c=$((c+1))

--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -353,8 +353,6 @@ function openvpn_connect() {
 
   config_id=$(echo "$1" | cut -d"@" -f1)
   tier=$(echo "$1" | cut -d"@" -f8)
-  name=$(echo "$1" | cut -d"@" -f2)
-  echo "Connecting to $name"
   selected_protocol=$2
   
   if [[ $selected_protocol == "" ]]; then


### PR DESCRIPTION
This fixes #73 by setting the DNS server based on the tier of the server rather than the tier of the user account. As I mentioned in the issue thread, this led me to refactor several functions throughout the script and I think the result is a little better than before.

Instead of having each type of connection (fastest, random, specific) call its own function to grab the server list from the API and parse it separately, each one now calls `get_vpn_config_details()`, which returns a list of "@" delimited properties, and includes the tier and score at the end of each. Each function then processes the fields it needs from this and when it finds a suitable server, it sends the whole line to `openvpn_connect`. 

Finally, since we were now extracting the numeric Tier and Score from the API, I decided to append these to the connection dialog menu. I replaced the Tier value (0-2) with the plan type ("F", "B", "P") because I figured it would be less confusing for users.

New connection menu with Tiers and Scores:

![screenshot from 2018-04-06 08-59-47](https://user-images.githubusercontent.com/12201350/38422482-ea9ce7a4-3978-11e8-80bd-ea3735b3210c.png)
