### PR TITLE
Fastest connect by country

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ sudo bash -c "git clone https://github.com/ProtonVPN/protonvpn-cli.git ; ./pro
 | `protonvpn-cli -c, --connect`                         | Select and connect to a ProtonVPN server.                                     |
 | `protonvpn-cli -c [server-name] [protocol]`           | Connect to a ProtonVPN server by name.                                        |
 | `protonvpn-cli -r, --random-connect`                  | Connect to a random ProtonVPN server.                                         |
-| `protonvpn-cli -f, --fastest-connect [country-code]`  | Connect to the fastest ProtonVPN server available in the world or by [country with country code](https://protonvpn.com/support/vpn-servers/). |
+| `protonvpn-cli -f, --fastest-connect [country-code]`  | Connect to the fastest ProtonVPN server available in the world or by [country](https://protonvpn.com/support/vpn-servers/). |
 | `protonvpn-cli -d, --disconnect`                      | Disconnect the current session.                                               |
 | `protonvpn-cli --ip`                                  | Print the current public IP address.                                          |
 | `protonvpn-cli --update`                              | Update protonvpn-cli.                                                         |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ sudo bash -c "git clone https://github.com/ProtonVPN/protonvpn-cli.git ; ./pro
 | `protonvpn-cli -c, --connect`                         | Select and connect to a ProtonVPN server.                                     |
 | `protonvpn-cli -c [server-name] [protocol]`           | Connect to a ProtonVPN server by name.                                        |
 | `protonvpn-cli -r, --random-connect`                  | Connect to a random ProtonVPN server.                                         |
-| `protonvpn-cli -f, --fastest-connect [country-code]`  | Connect to the fastest ProtonVPN server available in the world or by [country](https://protonvpn.com/support/vpn-servers/). |
+| `protonvpn-cli -f, --fastest-connect [country-code]`  | Connect to the fastest ProtonVPN server available in the world or by [country with country code](https://protonvpn.com/support/vpn-servers/). |
 | `protonvpn-cli -d, --disconnect`                      | Disconnect the current session.                                               |
 | `protonvpn-cli --ip`                                  | Print the current public IP address.                                          |
 | `protonvpn-cli --update`                              | Update protonvpn-cli.                                                         |

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ $ sudo bash -c "git clone https://github.com/ProtonVPN/protonvpn-cli.git ; ./pro
 
 # Usage #
 
-| **Command**                                  | **Description**                                              |
-| :------------------------------------------- | :----------------------------------------------------------- |
-| `protonvpn-cli --init`                       | Initialize ProtonVPN profile on the machine.                 |
-| `protonvpn-cli -c, --connect`                | Select and connect to a ProtonVPN server.                    |
-| `protonvpn-cli -c [server-name] [protocol]`  | Connect to a ProtonVPN server by name.                       |
-| `protonvpn-cli -r, --random-connect`         | Connect to a random ProtonVPN server.                        |
-| `protonvpn-cli -f, --fastest-connect`        | Connect to the fastest available ProtonVPN server.           |
-| `protonvpn-cli -d, --disconnect`             | Disconnect the current session.                              |
-| `protonvpn-cli --ip`                         | Print the current public IP address.                         |
-| `protonvpn-cli --update`                     | Update protonvpn-cli.                                        |
-| `protonvpn-cli --install`                    | Install protonvpn-cli.                                       |
-| `protonvpn-cli --uninstall`                  | Uninstall protonvpn-cli.                                     |
-| `protonvpn-cli --help`                       | Show help message.                                           |
+| **Command**                                           | **Description**                                                               |
+| :---------------------------------------------------- | :---------------------------------------------------------------------------- |
+| `protonvpn-cli --init`                                | Initialize ProtonVPN profile on the machine.                                  |
+| `protonvpn-cli -c, --connect`                         | Select and connect to a ProtonVPN server.                                     |
+| `protonvpn-cli -c [server-name] [protocol]`           | Connect to a ProtonVPN server by name.                                        |
+| `protonvpn-cli -r, --random-connect`                  | Connect to a random ProtonVPN server.                                         |
+| `protonvpn-cli -f, --fastest-connect [country-code]`  | Connect to the fastest ProtonVPN server available in the world or by [country](https://protonvpn.com/support/vpn-servers/). |
+| `protonvpn-cli -d, --disconnect`                      | Disconnect the current session.                                               |
+| `protonvpn-cli --ip`                                  | Print the current public IP address.                                          |
+| `protonvpn-cli --update`                              | Update protonvpn-cli.                                                         |
+| `protonvpn-cli --install`                             | Install protonvpn-cli.                                                        |
+| `protonvpn-cli --uninstall`                           | Uninstall protonvpn-cli.                                                      |
+| `protonvpn-cli --help`                                | Show help message.                                                            |
 
 
 protonvpn-cli can also be used by typing `pvpn`, once installed.

--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -538,8 +538,13 @@ function connect_to_fastest_vpn() {
   fi
 
   echo "Fetching ProtonVPN Servers..."
-  config_id=$(get_fastest_vpn_connection_id)
+  selected_country=$(echo "$1" | tr '[:lower:]' '[:upper:]')
   selected_protocol="udp"
+  config_id=$(get_fastest_vpn_connection_id "$selected_country")
+  if [[ "$?" == "2" ]]; then
+      echo "[!] Error: No available country matches $selected_country code"
+      exit 1
+  fi
   openvpn_connect "$config_id" "$selected_protocol"
 }
 
@@ -659,12 +664,15 @@ function get_fastest_vpn_connection_id() {
     --header 'Accept: application/vnd.protonmail.v1+json' \
     --timeout 20 -q -O /dev/stdout "https://api.protonmail.ch/vpn/logicals" | tee $(get_protonvpn_cli_home)/.response_cache)
   tier=$(cat "$(get_protonvpn_cli_home)/protonvpn_tier")
+  selected_country="$1"
+  NO_AVAILABLE_COUNTRY="NO_AVAILABLE_COUNTRY"
   output=`python <<END
 import json, math, random
 json_parsed_response = json.loads("""$response_output""")
 
 all_features = {"SECURE_CORE": 1, "TOR": 2, "P2P": 4, "XOR": 8, "IPV6": 16}
 excluded_features_on_fastest_connect = ["TOR"]
+selected_country = """$selected_country""" or None
 
 candidates_1 = []
 for _ in json_parsed_response["LogicalServers"]:
@@ -679,8 +687,14 @@ for _ in json_parsed_response["LogicalServers"]:
             is_excluded = True
     if is_excluded is True:
         continue
+    if selected_country and _["ExitCountry"] != selected_country:
+        continue
     if (_["Tier"] <= int("""$tier""")):
         candidates_1.append(_)
+
+if selected_country and 0 == len(candidates_1):
+    print("""$NO_AVAILABLE_COUNTRY""")
+    exit(1)
 
 candidates_2_size = float(len(candidates_1)) / 100.00 * 5.00
 candidates_2 = sorted(candidates_1, key=lambda l: l["Score"])[:int(math.ceil(candidates_2_size))]
@@ -689,6 +703,10 @@ vpn_connection_id = random_candidate["ID"]
 print(vpn_connection_id)
 
 END`
+
+if [[ "$output" == "$NO_AVAILABLE_COUNTRY" ]]; then
+    exit 2
+fi
 
   echo "$output"
 }
@@ -765,17 +783,17 @@ function help_message() {
     echo -e "ProtonVPN Command-Line Tool\n"
     echo -e "Usage: $(basename $0) [option]\n"
     echo "Options:"
-    echo "   --init                              Initialize ProtonVPN profile on the machine."
-    echo "   -c, --connect                       Select and connect to a ProtonVPN server."
-    echo "   -c [server-name] [protocol]         Connect to a ProtonVPN server by name."
-    echo "   -r, --random-connect                Connect to a random ProtonVPN server."
-    echo "   -f, --fastest-connect               Connect to the fastest available ProtonVPN server."
-    echo "   -d, --disconnect                    Disconnect the current session."
-    echo "   --ip                                Print the current public IP address."
-    echo "   --update                            Update protonvpn-cli."
-    echo "   --install                           Install protonvpn-cli."
-    echo "   --uninstall                         Uninstall protonvpn-cli."
-    echo "   -h, --help                          Show this help message."
+    echo "   --init                                 Initialize ProtonVPN profile on the machine."
+    echo "   -c, --connect                          Select and connect to a ProtonVPN server."
+    echo "   -c [server-name] [protocol]            Connect to a ProtonVPN server by name."
+    echo "   -r, --random-connect                   Connect to a random ProtonVPN server."
+    echo "   -f, --fastest-connect [country-code]   Connect to the fastest ProtonVPN server available in the world or by country."
+    echo "   -d, --disconnect                       Disconnect the current session."
+    echo "   --ip                                   Print the current public IP address."
+    echo "   --update                               Update protonvpn-cli."
+    echo "   --install                              Install protonvpn-cli."
+    echo "   --uninstall                            Uninstall protonvpn-cli."
+    echo "   -h, --help                             Show this help message."
     echo
 
     exit 0
@@ -790,7 +808,7 @@ case $user_input in
     ;;
   "-r"|"--r"|"-random"|"--random"|"-random-connect"|"--random-connect") connect_to_random_vpn
     ;;
-  "-f"|"--f"|"-fastest"|"--fastest"|"-fastest-connect"|"--fastest-connect") connect_to_fastest_vpn
+  "-f"|"--f"|"-fastest"|"--fastest"|"-fastest-connect"|"--fastest-connect") connect_to_fastest_vpn "$2"
     ;;
   "-c"|"-connect"|"--c"|"--connect")
     if [[ $# == 1 ]]; then


### PR DESCRIPTION
Hello, I submit this modification that will be useful to me is certainly for other users. This change allows you to connect to the fastest server per country.

If the user uses this command, he will be connected to the fastest server in the world.

`protonvpn-cli -f`

If the user uses the same command but with the code of the country in argument it will be connected to the fastest server of the country.
ex:
`protonvpn-cli -f NL`
`protonvpn-cli -f CH`