### PR TITLE
Fix "is openvpn running" test on systems running NetworkManager VPN

### DIFF
--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -404,7 +404,7 @@ function check_if_internet_is_working_normally() {
 }
 
 function is_openvpn_currently_running() {
-  if [[ $(pgrep openvpn) == "" ]]; then
+  if [[ $(pgrep -x openvpn) == "" ]]; then
     echo false
   else
     echo true


### PR DESCRIPTION
On some systems, there's [nm-openvpn-auth] process running. The present test for openvpn matches such a process and fails to connect. Adding -x fixes the problem as it matches only "openvpn" processes (exactly).