### PR TITLE
Avoid overwriting modified DNS upon restore

### DIFF
--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -352,6 +352,7 @@ function modify_dns() {
       done
     else # non-Mac
       echo -e "# ProtonVPN DNS - protonvpn-cli\nnameserver $dns_server" > "/etc/resolv.conf"
+      echo -e "# ProtonVPN DNS - protonvpn-cli\nnameserver $dns_server" > "$(get_protonvpn_cli_home)/.resolv.conf.protonvpn_applied_backup"
     fi
   fi
 
@@ -366,6 +367,7 @@ function modify_dns() {
       done
     else # non-Mac
       echo -e "# ProtonVPN DNS - Custom DNS\nnameserver $dns_server" > "/etc/resolv.conf"
+      echo -e "# ProtonVPN DNS - protonvpn-cli\nnameserver $dns_server" > "$(get_protonvpn_cli_home)/.resolv.conf.protonvpn_applied_backup"
     fi
   fi
 
@@ -383,7 +385,11 @@ function modify_dns() {
         fi
       done
     else # non-Mac
-      cp "$(get_protonvpn_cli_home)/.resolv.conf.protonvpn_backup" "/etc/resolv.conf"
+      if [[ $(diff "$(get_protonvpn_cli_home)/.resolv.conf.protonvpn_applied_backup" "/etc/resolv.conf") ]]; then
+        echo "[*] DNS was modified. Keeping the new version."
+      else
+        cp "$(get_protonvpn_cli_home)/.resolv.conf.protonvpn_backup" "/etc/resolv.conf"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
In openvpn_disconnect(), "modify_dns revert_to_backup" is called to
restore DNS to the value backed-up by openvpn_connect(). However,
DNS might change after the backup and before a --disconnect is issued.
In that case, --disconnect causes a needless overwrite of DNS with an
old value, that might as well break the internet connection.

Use case:

  * Client connects to protonvpn.
  * Client changes access point. Internet connection breaks.
  * Client issues a --disconnect to restore internet connection.
  * Internet connection remains broken due to DNS overwrite.
    New --connect attempts will fail.