### PR TITLE
Add deprecation warning in favor of protonvpn-cli-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 
 ![protonvpn-cli](https://i.imgur.com/tDrwkX5l.png)
 
+# Deprecation warning
+
+This Version of ProtonVPN-CLI has been deprecated and is no longer maintained by the ProtonVPN Team.
+
+It is superseded by Version 2. Due to the new version being written in Python, you can't update it with the `--update` option. The new version needs to be installed manually. For installation instructions, please visit the project page at
+
+https://github.com/ProtonVPN/protonvpn-cli-ng
+
+*Note: To disable the deprecation warning in the program, create a file called `deprecation_warning` in the `~/.protonvpn-cli` configuration folder.*
+
 # Overview #
 protonvpn-cli is a command-line tool for Linux and macOS.
 

--- a/protonvpn-cli.sh
+++ b/protonvpn-cli.sh
@@ -1533,6 +1533,16 @@ function help_message() {
     exit 0
 }
 
+if [ ! -f "$(get_protonvpn_cli_home)/deprecation_warning" ]; then
+  echo "[!] Deprecation warning [!]"
+  echo
+  echo "This Version of ProtonVPN-CLI has been deprecated and is no longer maintained by the ProtonVPN Team."
+  echo "It is superseded by Version 2. Due to the new version being written in Python, you can't"
+  echo "update it with the --update option. The new version needs to be installed manually." 
+  echo "For installation instructions, please visit the project page at"
+  echo "https://github.com/ProtonVPN/protonvpn-cli-ng"
+fi
+
 check_requirements
 user_input="$1"
 case $user_input in


### PR DESCRIPTION
With the [new Version](https://github.com/ProtonVPN/protonvpn-cli-ng) being released, this project is no longer maintained. In an effort to move users over to the new version, a deprecation warning would make sense.

Anyone who still wants to use this version can create the file `~/.protonvpn-cli/deprecation_warning` which will skip displaying the warning and allows normal usage.